### PR TITLE
Adjust `cglobal` to be statically evaluated

### DIFF
--- a/src/NautyGraphs.jl
+++ b/src/NautyGraphs.jl
@@ -17,10 +17,10 @@ include("graphs_api_extensions.jl")
 
 function __init__()
     # global default options to nauty carry a pointer reference that needs to be initialized at runtime
-    DEFAULTOPTIONS_DENSE16.dispatch = cglobal((:dispatch_graph, libnauty(UInt16)), Cvoid)
-    DEFAULTOPTIONS_DENSE32.dispatch = cglobal((:dispatch_graph, libnauty(UInt32)), Cvoid)
-    DEFAULTOPTIONS_DENSE64.dispatch = cglobal((:dispatch_graph, libnauty(UInt64)), Cvoid)
-    DEFAULTOPTIONS_SPARSE.dispatch = cglobal((:dispatch_sparse, libnauty(UInt64)), Cvoid)
+    DEFAULTOPTIONS_DENSE16.dispatch = cglobal((:dispatch_graph, nauty_jll.libnautyTS), Cvoid)
+    DEFAULTOPTIONS_DENSE32.dispatch = cglobal((:dispatch_graph, nauty_jll.libnautyTW), Cvoid)
+    DEFAULTOPTIONS_DENSE64.dispatch = cglobal((:dispatch_graph, nauty_jll.libnautyTL), Cvoid)
+    DEFAULTOPTIONS_SPARSE.dispatch = cglobal((:dispatch_sparse, nauty_jll.libnautyTL), Cvoid)
     return
 end
 


### PR DESCRIPTION
Calling a function like `libnauty(UInt16)` inside a `cglobal` is likely to be removed in future versions of Julia by https://github.com/JuliaLang/julia/pull/61709.

The trouble is that this behavior only works inconsistently, depending on whether the argument happens to statically evaluable in the world age computed by inference and furthermore the dynamic `cglobal` form is incompatible with `--trim`.

The "static" form resolves these issues and is compatible with future versions of Julia.